### PR TITLE
Fixed a null pointer exception in Pinger code

### DIFF
--- a/common/js/src/messaging/message-channel-pinging.js
+++ b/common/js/src/messaging/message-channel-pinging.js
@@ -217,8 +217,8 @@ Pinger.prototype.timeoutCallback_ = function() {
     return;
   this.logger.warning('No pong response received in time, the remote end is ' +
                       'dead. Disposing the messaging channel...');
-  this.dispose();
   this.messageChannel_.dispose();
+  this.dispose();
 };
 
 /**


### PR DESCRIPTION
dispose() was called on the pinger before calling messageChannel_.dispose(),
causing the messageChannel_ to be set to null

this commit fixes #2 