### PR TITLE
Fix Connector App fatal failure on trying to parse an invalid message

### DIFF
--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -192,6 +192,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
       GSC.PcscLiteCommon.Constants.REQUESTER_TITLE,
       clientMessageChannel,
       this);
+  this.requestReceiver_.setShouldDisposeOnInvalidMessage(true);
 
   /** @private */
   this.serverMessageChannel_ = serverMessageChannel;


### PR DESCRIPTION
Instead of failing (and reloading the whole app) when the message received from a client contains invalid data, the message channel should be disposed.