### PR TITLE
Fix possible crash in pcsc-lite-related debug code

### DIFF
--- a/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
+++ b/third_party/pcsc-lite/naclport/common/src/google_smart_card_pcsc_lite_common/scard_debug_dump.cc
@@ -346,7 +346,7 @@ std::string DebugDumpSCardOutputBuffer(
   const void* const contents = is_autoallocated ?
       *reinterpret_cast<const void* const*>(buffer) : buffer;
   const std::string dumped_value = "<" +
-      (buffer_size ? DebugDumpSCardBufferContents(buffer, *buffer_size) :
+      (buffer_size ? DebugDumpSCardBufferContents(contents, *buffer_size) :
            "DATA OF UNKNOWN LENGTH") + ">";
   return is_autoallocated ? HexDumpPointer(buffer) + "(" + dumped_value + ")" :
       dumped_value;


### PR DESCRIPTION
This fixes the potential memory access violation that could occur in the debug printing code in the PC/SC-Lite client NaCl port.

The crash could happen when the SCARD_AUTOALLOCATE feature is used and the debug tracing of the executed PC/SC-Lite functions was enabled. The buggy code would try to dump the buffer contents from the address storing the buffer address (instead of dereferencing the pointer and then dumping the bytes).

BTW, this code path is used only on the client side, not on the server side - so there were no security implications for the Connector app.

The bug was discovered because of a hint from clang-tidy (the local variable containing the correct pointer was assigned, but never used).