### PR TITLE
Fix PC/SC-Lite client handling error when the server is destroyed

### DIFF
--- a/smart_card_connector_app/src/background.js
+++ b/smart_card_connector_app/src/background.js
@@ -153,6 +153,16 @@ function createClientHandler(clientMessageChannel, clientExtensionId) {
            '(client extension id is "' + clientExtensionId + '")' :
            '(client is the own App)') +
       '...');
+  GSC.Logging.checkWithLogger(logger, !clientMessageChannel.isDisposed());
+
+  if (naclModule.isDisposed() || naclModule.messageChannel.isDisposed()) {
+    logger.warning(
+        'Could not create PC/SC-Lite client handler as the server is ' +
+        'disposed. Disposing of the client message channel...');
+    clientMessageChannel.dispose();
+    return;
+  }
+
   // Note: the reference to the created client handler is not stored anywhere,
   // because it manages its lifetime itself, based on the lifetimes of the
   // passed message channels.

--- a/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
+++ b/third_party/pcsc-lite/naclport/server_clients_management/src/client-handler.js
@@ -215,7 +215,7 @@ GSC.PcscLiteServerClientsManagement.ClientHandler = function(
    */
   this.bufferedRequestsQueue_ = new goog.structs.Queue;
 
-  this.addChannelDisposedListeners_(serverMessageChannel, clientMessageChannel);
+  this.addChannelDisposedListeners_();
 
   this.logger.fine('Initialized');
 };
@@ -363,11 +363,10 @@ ClientHandler.prototype.handleRequest = function(payload) {
  * channels.
  * @private
  */
-ClientHandler.prototype.addChannelDisposedListeners_ = function(
-    serverMessageChannel, clientMessageChannel) {
-  serverMessageChannel.addOnDisposeCallback(
+ClientHandler.prototype.addChannelDisposedListeners_ = function() {
+  this.serverMessageChannel_.addOnDisposeCallback(
       this.serverMessageChannelDisposedListener_.bind(this));
-  clientMessageChannel.addOnDisposeCallback(
+  this.clientMessageChannel_.addOnDisposeCallback(
       this.clientMessageChannelDisposedListener_.bind(this));
 };
 
@@ -381,7 +380,7 @@ ClientHandler.prototype.addChannelDisposedListeners_ = function(
 ClientHandler.prototype.serverMessageChannelDisposedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.info('Server message channel was disposed, disposing...');
+  this.logger.warning('Server message channel was disposed, disposing...');
 
   // Note: this assignment is important because it prevents from sending of any
   // messages through the server message channel, which is normally happening
@@ -482,7 +481,7 @@ ClientHandler.prototype.serverReadyListener_ = function() {
 ClientHandler.prototype.serverReadinessFailedListener_ = function() {
   if (this.isDisposed())
     return;
-  this.logger.finer('The server failed to become ready, disposing...');
+  this.logger.warning('The server failed to become ready, disposing...');
   this.dispose();
 };
 


### PR DESCRIPTION
This fixes JS fatal errors that could happen when a client tried to
connect to the Connector app after the server message channel was destroyed
(e.g. because of the NaCl module crash).

The problem was that the ClientHandler class constructor could be called
with an undefined value instead of the server message channel (where the
undefined value originates from accessing a property of already disposed
NaclModule object).