### PR TITLE
Protect debug dumping code against undefined classes

### DIFF
--- a/common/js/src/logging/debug-dump.js
+++ b/common/js/src/logging/debug-dump.js
@@ -187,13 +187,13 @@ GSC.DebugDump.dump = function(value) {
   // produce thorny false positives.
   //
   // TODO(emaxx): Think about a proper solution that deals with cyclic references.
-  if (value instanceof Document)
+  if (Document && value instanceof Document)
     return '<Document>';
-  if (value instanceof Window)
+  if (Window && value instanceof Window)
     return '<Window>';
-  if (value instanceof NodeList)
+  if (NodeList && value instanceof NodeList)
     return '<NodeList>';
-  if (value instanceof Node) {
+  if (Node && value instanceof Node) {
     // Note that this branch should go after other branches checking for
     // DOM-related types.
     return '<Node>';


### PR DESCRIPTION
Ivan, PTAL.

This hopefully fixes a intermittent problem that I observed when debug dump function failed with TypeError saying that right-hand argument of "instanceof" operator cannot be undefined. This is a pretty mysterious error - my guess was that some standard classes are not initialized by the time when the extension code starts.