### PR TITLE
Example: fix download script

### DIFF
--- a/example_js_standalone_smart_card_client_app/download-google-smart-card-client-library.py
+++ b/example_js_standalone_smart_card_client_app/download-google-smart-card-client-library.py
@@ -47,8 +47,11 @@ def main():
       client_library_download_url))
   client_library = urllib2.urlopen(client_library_download_url).read()
 
-  output_file_path = os.path.join(
-      os.path.relpath(os.path.dirname(__file__)), OUTPUT_FILE_NAME)
+  if os.path.dirname(__file__):
+      output_file_path = os.path.join(
+          os.path.relpath(os.path.dirname(__file__)), OUTPUT_FILE_NAME)
+  else:
+      output_file_path = OUTPUT_FILE_NAME
   with open(output_file_path, "wt") as f:
     f.write(client_library)
 


### PR DESCRIPTION
Fix the script execution when no directory is specified.

The problem was:
$ python download-google-smart-card-client-library.py
Accessing GitHub API...
Downloading from "https://github.com/GoogleChrome/chromeos_smart_card_connector/releases/download/1.2.7.0/google-smart-card-client-library.js"...
Traceback (most recent call last):
  File "download-google-smart-card-client-library.py", line 60, in <module>
    main()
  File "download-google-smart-card-client-library.py", line 51, in main
    os.path.relpath(os.path.dirname(__file__)), OUTPUT_FILE_NAME)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 428, in relpath
    raise ValueError("no path specified")
ValueError: no path specified